### PR TITLE
Fix copy/paste typos in the delayed and late description

### DIFF
--- a/doc/v1/index.html
+++ b/doc/v1/index.html
@@ -2205,12 +2205,12 @@ $</pre>
         <tr>
           <td>401</td>
           <td>Delayed</td>
-          <td>The flight is currently considered to be on time, which means that the (EstimatedDepartureDateTime - ScheduledDepartureDateTime) &gt;= 15 minutes.</td>
+          <td>The flight is currently considered to be delayed, which means that the (EstimatedDepartureDateTime - ScheduledDepartureDateTime) &gt;= 15 minutes.</td>
         </tr>
         <tr>
           <td>402</td>
           <td>In Flight - late</td>
-          <td>The flight is currently in the air and is considered to be on time, which means that the (EstimatedArrivalDateTime - ScheduledArrivalDateTime) &gt;= 15 minutes.</td>
+          <td>The flight is currently in the air and is considered to be late, which means that the (EstimatedArrivalDateTime - ScheduledArrivalDateTime) &gt;= 15 minutes.</td>
         </tr>
         <tr>
           <td>403</td>


### PR DESCRIPTION
Looks like copy/paste created these typos.

Signed-off-by: Phil Estes estesp@gmail.com
