### PR TITLE
Removed references to status.tripit.com which no longer exists.

### DIFF
--- a/doc/v1/crs.html
+++ b/doc/v1/crs.html
@@ -64,10 +64,6 @@
       first familiarize themselves with the public TripIt API documentation available
       <a href="http://tripit.github.com/api/doc/v1/">here</a>.
     </p>
-    <p>
-      For status on maintenance windows and operational issues related to the CRS API please
-      go to our status blog at <a href="http://status.tripit.com/">status.tripit.com</a>.
-    </p>
 
     <h2 id="authentication_section">Authentication</h2>
     <h3>2-legged OAuth</h3>

--- a/doc/v1/index.html
+++ b/doc/v1/index.html
@@ -73,11 +73,6 @@
       such as all of a user's upcoming trips or all travel objects
       contained within a specific trip.
     </p>
-    <p>
-      For status on maintenance windows and operational issues related
-      to the API please go to our status blog
-      at <a href="http://status.tripit.com/">status.tripit.com</a>.
-    </p>
 
     <h2 id="language_bindings_section">Language Bindings</h1>
     <p>


### PR DESCRIPTION
Just updating the documentation to remove reference to status.tripit.com which no longer exists.