### PR TITLE
Renaming FlightStatus to Status

### DIFF
--- a/doc/v1/index.html
+++ b/doc/v1/index.html
@@ -2042,10 +2042,10 @@ $</pre>
     <p>
       Each one of these is discussed in more detail below.
     </p>
-    <h3>AirObject :: AirSegment :: FlightStatus</h3>
+    <h3>AirObject :: AirSegment :: Status</h3>
     <p>
-      The FlightStatus object is defined here in the object XSD here: <a href="https://api.tripit.com/xsd/tripit-api-obj-v1.xsd">tripit-api-obj-v1.xsd</a>.
-      Here's a definition of all of the properties within the FlightStatus object:
+      The Status object is defined here in the object XSD here: <a href="https://api.tripit.com/xsd/tripit-api-obj-v1.xsd">tripit-api-obj-v1.xsd</a>.
+      Here's a definition of all of the properties within the Status object:
     </p>
     <p>
       <table>
@@ -2112,7 +2112,7 @@ $</pre>
         </tr>
         <tr>
           <td>layover_minutes</td>
-          <td>If layover_minutes is contained within the FlightStatus object
+          <td>If layover_minutes is contained within the Status object
               contained with an AirSegment that
               isn't the last segment in a leg the value of layover_minutes
               will be the number of minutes between this segment's arrival


### PR DESCRIPTION
API returns all flight related information in Status field, not in FlightStatus. Will update XSD accordingly.