### PR TITLE
Removing unsupported resources links

### DIFF
--- a/doc/v1/index.html
+++ b/doc/v1/index.html
@@ -192,19 +192,8 @@ Pragma: no-cache
     <h3 id="oauth">OAuth</h3>
     <h4>References</h4>
     <p>
-      For more information about
-      the <a href="http://oauth.net/">OAuth</a> specification the
-      following references are useful:
-    </p>
-    <p>
-      <ul>
-        <li><a href="http://oauth.net/">OAuth Specification</a></li>
-        <li><a href="http://code.google.com/p/oauth/">Reference Implementations</a></li>
-        <li><a href="http://hueniverse.com/2007/10/04/beginners-guide-to-oauth-part-i-overview/">Beginner's Guide to OAuth - Part I: Overview</a></li>
-        <li><a href="http://hueniverse.com/2007/10/15/beginners-guide-to-oauth-part-ii-protocol-workflow/">Beginner's Guide to OAuth - Part II : Protocol Workflow</a></li>
-        <li><a href="http://hueniverse.com/2008/10/03/beginners-guide-to-oauth-part-iii-security-architecture/">Beginner's Guide to OAuth - Part III : Security Architecture</a></li>
-        <li><a href="http://hueniverse.com/2008/10/08/beginners-guide-to-oauth-part-iv-signing-requests/">Beginner's Guide to OAuth - Part IV: Signing Requests</a></li>
-      </ul>
+      You can find more information about the
+      the OAuth specification <a href="https://oauth.net/core/1.0/">here</a>.
     </p>
     <p>
       It is beyond the scope of this document to describe the
@@ -213,7 +202,7 @@ Pragma: no-cache
       the TripIt API should be familiar with the documentation listed
       in the 'References' section as the rest of the documentation is
       written assuming the reader understands OAuth terminology and
-      concepts.  The following 4 steps is heavily modeled on the OAuth
+      concepts.  The following 4 steps are heavily modeled on the OAuth
       1.0 specification document itself.  The similarities are not a
       coincidence and each step tracks back to the relevant section in
       the spec so the reader can more easily follow along.

--- a/doc/v1/index.html
+++ b/doc/v1/index.html
@@ -193,7 +193,7 @@ Pragma: no-cache
     <h4>References</h4>
     <p>
       You can find more information about the
-      the OAuth specification <a href="https://oauth.net/core/1.0/">here</a>.
+      OAuth specification <a href="https://oauth.net/core/1.0/">here</a>.
     </p>
     <p>
       It is beyond the scope of this document to describe the


### PR DESCRIPTION
The first 3 parts of "Beginner's Guide to OAuth" are still available, but the 4th part is not. I confirmed with the author that it will no longer be available.