### PR TITLE
Removed leading scheme://hostname for crs.html

### DIFF
--- a/doc/v1/crs.html
+++ b/doc/v1/crs.html
@@ -62,7 +62,7 @@
       The TripIt CRS API is built on top of the <i>public TripIt API</i>.  Since both API's
       share many of the same fundamentals, it will be helpful for anyone using the CRS API to
       first familiarize themselves with the public TripIt API documentation available
-      <a href="http://tripit.github.com/api/doc/v1/">here</a>.
+      <a href="/api/doc/v1/">here</a>.
     </p>
 
     <h2 id="authentication_section">Authentication</h2>
@@ -162,21 +162,21 @@
     <p>
       For information on <i>Web Authentication</i> and standard
       <i>3-legged OAuth</i>, please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#authentication_section">public TripIt API</a>
+      <a href="/api/doc/v1/#authentication_section">public TripIt API</a>
       documentation.
     </p>
 
     <h2 id="encoding_section">Encoding</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#encoding_section">public TripIt API</a>
+      <a href="/api/doc/v1/#encoding_section">public TripIt API</a>
       documentation.
     </p>
 
     <h2 id="resource_section">Resource URLs</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#resource_section">public TripIt API</a>
+      <a href="/api/doc/v1/#resource_section">public TripIt API</a>
       documentation for general information, portions of which pertain to partners' use of the
       CRS API.  The following documentation describes CRS-specific resource URLs available
       only in the TripIt CRS API.
@@ -398,7 +398,7 @@ Think of TripCrsRemark's as providing you the ability to store notes on a per-tr
     <h2 id="http_status_codes_section">HTTP Status Codes</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#http_status_codes_section">public TripIt API</a>
+      <a href="/api/doc/v1/#http_status_codes_section">public TripIt API</a>
       documentation as well as the following CRS-specific documentation below.
     </p>
     <p>
@@ -426,7 +426,7 @@ Think of TripCrsRemark's as providing you the ability to store notes on a per-tr
     <h2 id="request_response_section">Request/Response Objects</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#request_response_section">public TripIt API</a>
+      <a href="/api/doc/v1/#request_response_section">public TripIt API</a>
       documentation as well as the following CRS-specific documentation below.
     </p>
     <p>
@@ -614,28 +614,28 @@ email_address%3Duser%40@some-company.com
     <h2 id="pro_data_section">TripIt Pro Data</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#deprecation_policy_section">public TripIt API</a>
+      <a href="/api/doc/v1/#deprecation_policy_section">public TripIt API</a>
       documentation.
     </p>
 
     <h2 id="deprecation_policy_section">Deprecation Policy</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#deprecation_policy_section">public TripIt API</a>
+      <a href="/api/doc/v1/#deprecation_policy_section">public TripIt API</a>
       documentation.
     </p>
 
     <h2 id="release_notes_section">Release Notes</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#release_notes_section">public TripIt API</a>
+      <a href="/api/doc/v1/#release_notes_section">public TripIt API</a>
       documentation.
     </p>
 
     <h2 id="examples_section">Examples</h2>
     <p>
       Please refer to the
-      <a href="http://tripit.github.com/api/doc/v1/#examples_section">public TripIt API</a>
+      <a href="/api/doc/v1/#examples_section">public TripIt API</a>
       documentation.
     </p>
 


### PR DESCRIPTION
References:
https://github.blog/2013-04-05-new-github-pages-domain-github-io/
and
https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/